### PR TITLE
YL - fixed invalid date when not entering time

### DIFF
--- a/src/components/NewToDo/ToDoForm.js
+++ b/src/components/NewToDo/ToDoForm.js
@@ -3,7 +3,7 @@ import "./ToDoForm.css";
 
 const ToDoForm = (props) => {
   const [enteredTitle, setEnteredTitle] = useState("");
-  const [enteredPriority, setEnteredPriority] = useState("Low");
+  const [enteredPriority, setEnteredPriority] = useState("low");
   const [enteredDate, setEnteredDate] = useState("");
   const [enteredTime, setEnteredTime] = useState("");
   const [enteredTag, setEnteredTag] = useState("");
@@ -33,12 +33,14 @@ const ToDoForm = (props) => {
     let dateAndTime = enteredDate + "T" + enteredTime;
     if (dateAndTime === "T") {
       dateAndTime = new Date();
+      console.log("here");
     } else {
-      dateAndTime = new Date(dateAndTime);
+      dateAndTime = new Date();
     }
+    console.log(dateAndTime);
     let Title = enteredTitle;
     let Priority = enteredPriority;
-    if (Title === "") {Title = "Unnamed";}
+    if (Title === "") {Title = "Untitled";}
     if (Priority==="") {Priority = "low";}
     const ToDoData = {
       title: Title,
@@ -47,6 +49,8 @@ const ToDoForm = (props) => {
       complete: false,
       tag: enteredTag
     };
+
+    console.log(ToDoData);
 
     props.onSaveToDoData(ToDoData);
     setEnteredTitle("");

--- a/src/components/NewToDo/ToDoForm.js
+++ b/src/components/NewToDo/ToDoForm.js
@@ -33,11 +33,18 @@ const ToDoForm = (props) => {
     let dateAndTime = enteredDate + "T" + enteredTime;
     if (dateAndTime === "T") {
       dateAndTime = new Date();
-      console.log("here");
-    } else {
-      dateAndTime = new Date();
+    } 
+    if (enteredDate !== "") {
+      const temp1 = new Date(enteredDate);
+      dateAndTime = temp1;
     }
-    console.log(dateAndTime);
+    if (enteredTime !== "") {
+      const temp2 = new Date();
+      temp2.setHours(enteredTime.substring(0,2));
+      temp2.setMinutes(enteredTime.substring(3));
+      temp2.setSeconds(0);
+      dateAndTime = temp2;
+    }
     let Title = enteredTitle;
     let Priority = enteredPriority;
     if (Title === "") {Title = "Untitled";}
@@ -49,8 +56,6 @@ const ToDoForm = (props) => {
       complete: false,
       tag: enteredTag
     };
-
-    console.log(ToDoData);
 
     props.onSaveToDoData(ToDoData);
     setEnteredTitle("");


### PR DESCRIPTION
Fixed the bug "invalid date" when not inputting anything to the due date and time.

Now if the user doesn't input anything to the due time and date, the default due time is set to the current time and the default priority is low.

<img width="1440" alt="Screenshot 2023-01-15 at 1 24 56 PM" src="https://user-images.githubusercontent.com/86722488/212568076-b934af08-b2b1-4141-8763-c7239f883232.png">
